### PR TITLE
Fix opening-brace handling in split_parameters

### DIFF
--- a/flexbe_webui/tools.py
+++ b/flexbe_webui/tools.py
@@ -180,7 +180,7 @@ def format_state_code_string(code_string, target_line_length, ws=' '):
         current = ''
         inside_brackets = 0
         for char in line:
-            if char in ('[', '(', '}'):
+            if char in ('[', '(', '{'):
                 inside_brackets += 1
             elif char in (']', ')', '}'):
                 inside_brackets -= 1


### PR DESCRIPTION
The bracket-depth counter listed '}' as an opening bracket and omitted
'{', so dict/set literals passed as state parameters were split at their
internal commas, corrupting formatted state code.
